### PR TITLE
Make back command able to go back to previous teleporting location.

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbutilities/FTBUtilitiesPermissions.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/FTBUtilitiesPermissions.java
@@ -51,12 +51,13 @@ public class FTBUtilitiesPermissions
 	public static final Node WARPS_COOLDOWN = Node.get("ftbutilities.warps.cooldown");
 	public static final Node WARPS_WARMUP = Node.get("ftbutilities.warps.warmup");
 
-	public static final Node HOMES_BACK = Node.get("ftbutilities.back.home");
-	public static final Node WARPS_BACK = Node.get("ftbutilities.back.warp");
-	public static final Node SPAWN_BACK = Node.get("ftbutilities.back.spawn");
-	public static final Node TPA_BACK = Node.get("ftbutilities.back.tpa");
-	public static final Node RTP_BACK = Node.get("ftbutilities.back.rtp");
-	public static final Node RESPAWN_BACK = Node.get("ftbutilities.back.respawn");
+	public static final String HOMES_BACK = "ftbutilities.back.home";
+	public static final String WARPS_BACK = "ftbutilities.back.warp";
+	public static final String SPAWN_BACK = "ftbutilities.back.spawn";
+	public static final String TPA_BACK = "ftbutilities.back.tpa";
+	public static final String RTP_BACK = "ftbutilities.back.rtp";
+	public static final String RESPAWN_BACK = "ftbutilities.back.respawn";
+	public static final String BACK_BACK = "ftbutilities.back.back";
 
 	// Claims //
 	public static final String CLAIMS_OTHER_SEE_INFO = "ftbutilities.other_player.claims.see_info";
@@ -146,6 +147,13 @@ public class FTBUtilitiesPermissions
 		PermissionAPI.registerNode(EDIT_WORLD_GAMERULES, DefaultPermissionLevel.OP, "Allow to edit gamerules via Admin Panel");
 		PermissionAPI.registerNode(TPA_CROSS_DIM, DefaultPermissionLevel.ALL, "Can use /tpa to teleport to/from another dimension");
 		PermissionAPI.registerNode(HEAL_OTHER, DefaultPermissionLevel.OP, "Allow to heal other players");
+		PermissionAPI.registerNode(HOMES_BACK, DefaultPermissionLevel.OP, "Allow player back to last time where /home is used");
+		PermissionAPI.registerNode(WARPS_BACK, DefaultPermissionLevel.OP, "Allow player back to last time where /warp is used");
+		PermissionAPI.registerNode(BACK_BACK,DefaultPermissionLevel.OP, "Allow player back to last time where /back is used");
+		PermissionAPI.registerNode(SPAWN_BACK,DefaultPermissionLevel.OP, "Allow player back to last time where /spawn is used");
+		PermissionAPI.registerNode(TPA_BACK, DefaultPermissionLevel.OP, "Allow player back to last time where /tpa is used");
+		PermissionAPI.registerNode(RTP_BACK, DefaultPermissionLevel.OP, "Allow player back to last time where /rtp is used");
+		PermissionAPI.registerNode(RESPAWN_BACK, DefaultPermissionLevel.ALL, "Allow player back to last death point");
 
 		for (Block block : Block.REGISTRY)
 		{

--- a/src/main/java/com/feed_the_beast/ftbutilities/FTBUtilitiesPermissions.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/FTBUtilitiesPermissions.java
@@ -51,6 +51,13 @@ public class FTBUtilitiesPermissions
 	public static final Node WARPS_COOLDOWN = Node.get("ftbutilities.warps.cooldown");
 	public static final Node WARPS_WARMUP = Node.get("ftbutilities.warps.warmup");
 
+	public static final Node HOMES_BACK = Node.get("ftbutilities.back.home");
+	public static final Node WARPS_BACK = Node.get("ftbutilities.back.warp");
+	public static final Node SPAWN_BACK = Node.get("ftbutilities.back.spawn");
+	public static final Node TPA_BACK = Node.get("ftbutilities.back.tpa");
+	public static final Node RTP_BACK = Node.get("ftbutilities.back.rtp");
+	public static final Node RESPAWN_BACK = Node.get("ftbutilities.back.respawn");
+
 	// Claims //
 	public static final String CLAIMS_OTHER_SEE_INFO = "ftbutilities.other_player.claims.see_info";
 	public static final String CLAIMS_OTHER_CLAIM = "ftbutilities.other_player.claims.claim";

--- a/src/main/java/com/feed_the_beast/ftbutilities/command/tp/CmdBack.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/command/tp/CmdBack.java
@@ -7,6 +7,7 @@ import com.feed_the_beast.ftbutilities.FTBUtilities;
 import com.feed_the_beast.ftbutilities.FTBUtilitiesPermissions;
 import com.feed_the_beast.ftbutilities.data.FTBUtilitiesPlayerData;
 import com.feed_the_beast.ftbutilities.data.TeleportLog;
+import com.feed_the_beast.ftbutilities.data.TeleportType;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -41,7 +42,9 @@ public class CmdBack extends CmdBase
 		{
 			if (!PermissionAPI.hasPermission(player, FTBUtilitiesPermissions.INFINITE_BACK_USAGE))
 			{
-				data.clearLastTeleport(lastTeleportLog.teleportType);
+				for(TeleportType t : TeleportType.values()) {
+					data.clearLastTeleport(t);
+				}
 			}
 		});
 	}

--- a/src/main/java/com/feed_the_beast/ftbutilities/command/tp/CmdBack.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/command/tp/CmdBack.java
@@ -6,6 +6,7 @@ import com.feed_the_beast.ftblib.lib.data.ForgePlayer;
 import com.feed_the_beast.ftbutilities.FTBUtilities;
 import com.feed_the_beast.ftbutilities.FTBUtilitiesPermissions;
 import com.feed_the_beast.ftbutilities.data.FTBUtilitiesPlayerData;
+import com.feed_the_beast.ftbutilities.data.TeleportLog;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -27,18 +28,20 @@ public class CmdBack extends CmdBase
 
 		FTBUtilitiesPlayerData data = FTBUtilitiesPlayerData.get(p);
 
-		if (data.getLastTeleport() == null)
+		TeleportLog lastTeleportLog = data.getLastTeleportLog();
+
+		if (lastTeleportLog == null)
 		{
 			throw FTBUtilities.error(sender, "ftbutilities.lang.warps.no_dp");
 		}
 
 		data.checkTeleportCooldown(sender, FTBUtilitiesPlayerData.Timer.BACK);
 
-		FTBUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> data.getLastTeleport().teleporter(), universe ->
+		FTBUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> lastTeleportLog.teleporter(), universe ->
 		{
 			if (!PermissionAPI.hasPermission(player, FTBUtilitiesPermissions.INFINITE_BACK_USAGE))
 			{
-				data.clearLastTeleport();
+				data.clearLastTeleport(lastTeleportLog.teleportType);
 			}
 		});
 	}

--- a/src/main/java/com/feed_the_beast/ftbutilities/command/tp/CmdBack.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/command/tp/CmdBack.java
@@ -27,18 +27,18 @@ public class CmdBack extends CmdBase
 
 		FTBUtilitiesPlayerData data = FTBUtilitiesPlayerData.get(p);
 
-		if (data.getLastDeath() == null)
+		if (data.getLastTeleport() == null)
 		{
 			throw FTBUtilities.error(sender, "ftbutilities.lang.warps.no_dp");
 		}
 
 		data.checkTeleportCooldown(sender, FTBUtilitiesPlayerData.Timer.BACK);
 
-		FTBUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> data.getLastDeath().teleporter(), universe ->
+		FTBUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> data.getLastTeleport().teleporter(), universe ->
 		{
 			if (!PermissionAPI.hasPermission(player, FTBUtilitiesPermissions.INFINITE_BACK_USAGE))
 			{
-				data.setLastDeath(null);
+				data.clearLastTeleport();
 			}
 		});
 	}

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
@@ -44,12 +44,12 @@ public class FTBUtilitiesPlayerData extends PlayerData
 
 	public enum Timer
 	{
-		HOME(TeleportType.HOME,FTBUtilitiesPermissions.HOMES_COOLDOWN, FTBUtilitiesPermissions.HOMES_WARMUP),
-		WARP(TeleportType.WARP,FTBUtilitiesPermissions.WARPS_COOLDOWN, FTBUtilitiesPermissions.WARPS_WARMUP),
-		BACK(TeleportType.BACK,FTBUtilitiesPermissions.BACK_COOLDOWN, FTBUtilitiesPermissions.BACK_WARMUP),
-		SPAWN(TeleportType.SPAWN,FTBUtilitiesPermissions.SPAWN_COOLDOWN, FTBUtilitiesPermissions.SPAWN_WARMUP),
-		TPA(TeleportType.TPA,FTBUtilitiesPermissions.TPA_COOLDOWN, FTBUtilitiesPermissions.TPA_WARMUP),
-		RTP(TeleportType.RTP,FTBUtilitiesPermissions.RTP_COOLDOWN, FTBUtilitiesPermissions.RTP_WARMUP);
+		HOME(TeleportType.HOME),
+		WARP(TeleportType.WARP),
+		BACK(TeleportType.BACK),
+		SPAWN(TeleportType.SPAWN),
+		TPA(TeleportType.TPA),
+		RTP(TeleportType.RTP);
 
 		public static final Timer[] VALUES = values();
 
@@ -57,11 +57,11 @@ public class FTBUtilitiesPlayerData extends PlayerData
 		private final Node warmup;
 		private final TeleportType teleportType;
 
-		Timer(TeleportType teleportType, Node c, Node w)
+		Timer(TeleportType teleportType)
 		{
 			this.teleportType = teleportType;
-			this.cooldown = c;
-			this.warmup = w;
+			this.cooldown = teleportType.getCooldownPermission();
+			this.warmup = teleportType.getWarmupPermission();
 		}
 
 		public void teleport(EntityPlayerMP player, Function<EntityPlayerMP, TeleporterDimPos> pos, @Nullable IScheduledTask extraTask)

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
@@ -26,7 +26,6 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.HoverEvent;
-import net.minecraftforge.common.util.INBTSerializable;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -41,15 +40,6 @@ public class FTBUtilitiesPlayerData extends PlayerData
 	public static final String TAG_FLY = "fly";
 	public static final String TAG_MUTED = "muted";
 	public static final String TAG_LAST_CHUNK = "ftbu_lchunk";
-
-	private enum TeleportType {
-		HOME,
-		WARP,
-		BACK,
-		SPAWN,
-		TPA,
-		RTP,
-	}
 
 	public enum Timer
 	{
@@ -155,47 +145,6 @@ public class FTBUtilitiesPlayerData extends PlayerData
 				player.sendStatusMessage(new TextComponentString(Integer.toString(secondsLeft - 1)), true);
 				player.sendStatusMessage(StringUtils.color(FTBLib.lang(player, "stand_still", startSeconds).appendText(" [" + (secondsLeft - 1) + "]"), TextFormatting.GOLD), true);
 			}
-		}
-	}
-
-
-	private class TeleportRecord implements INBTSerializable<NBTTagCompound>
-	{
-		private static final String NBT_KEY_X = "x";
-		private static final String NBT_KEY_Y = "y";
-		private static final String NBT_KEY_Z = "z";
-		private static final String NBT_KEY_DIMENSION = "dimension";
-		private static final String NBT_KEY_TELEPORT_TYPE = "teleportType";
-		BlockDimPos from;
-		TeleportType teleportType;
-		TeleportRecord(TeleportType teleportType, BlockDimPos from) {
-			this.teleportType = teleportType;
-			this.from = from;
-		}
-
-		@Override
-		public NBTTagCompound serializeNBT()
-		{
-			NBTTagCompound nbt = new NBTTagCompound();
-			nbt.setInteger(NBT_KEY_DIMENSION, from.dim);
-			nbt.setInteger(NBT_KEY_X, from.posX);
-			nbt.setInteger(NBT_KEY_Y, from.posY);
-			nbt.setInteger(NBT_KEY_Z, from.posZ);
-			nbt.setInteger(NBT_KEY_TELEPORT_TYPE, teleportType.ordinal());
-			return nbt;
-		}
-
-		@Override
-		public void deserializeNBT(NBTTagCompound nbt)
-		{
-			final int posX, posY, posZ, dimension, teleportType;
-			posX = nbt.getInteger(NBT_KEY_X);
-			posY = nbt.getInteger(NBT_KEY_Y);
-			posZ = nbt.getInteger(NBT_KEY_Z);
-			dimension = nbt.getInteger(NBT_KEY_DIMENSION);
-			teleportType = nbt.getInteger(NBT_KEY_TELEPORT_TYPE);
-			this.from = new BlockDimPos(posX, posY,posZ, dimension);
-			this.teleportType = TeleportType.values()[teleportType];
 		}
 	}
 

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
@@ -118,7 +118,7 @@ public class FTBUtilitiesPlayerData extends PlayerData
 				if (teleporter != null)
 				{
 					FTBUtilitiesPlayerData data = get(universe.getPlayer(player));
-					data.setLastTeleport(teleportType, new BlockDimPos(player.getRidingEntity()));
+					data.setLastTeleport(teleportType, new BlockDimPos(player));
 					teleporter.teleport(player);
 
 					if (player.getRidingEntity() != null)
@@ -341,5 +341,13 @@ public class FTBUtilitiesPlayerData extends PlayerData
 			return;
 		}
 		this.lastTeleportRecord = new TeleportRecord(teleportType, from);
+	}
+
+	public TeleportRecord getLastTeleport() {
+		return this.lastTeleportRecord;
+	}
+
+	public void clearLastTeleport() {
+		this.lastTeleportRecord = null;
 	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
@@ -165,7 +165,7 @@ public class FTBUtilitiesPlayerData extends PlayerData
 
 	private BlockDimPos lastSafePos;
 	private long[] lastTeleport;
-	private TeleportRecord lastTeleportRecord;
+	private TeleportLog lastTeleportRecord;
 	public final BlockDimPosStorage homes;
 
 	public FTBUtilitiesPlayerData(ForgePlayer player)
@@ -274,7 +274,7 @@ public class FTBUtilitiesPlayerData extends PlayerData
 	@Nullable
 	public BlockDimPos getLastDeath()
 	{
-		TeleportRecord lastTeleport = getLastTeleport();
+		TeleportLog lastTeleport = getLastTeleport();
 		if (lastTeleport == null) {
 			return null;
 		}
@@ -347,12 +347,12 @@ public class FTBUtilitiesPlayerData extends PlayerData
 		if (teleportType == TeleportType.BACK) {
 			return;
 		}
-		this.lastTeleportRecord = new TeleportRecord(teleportType, from);
+		this.lastTeleportRecord = new TeleportLog(teleportType, from);
 		player.markDirty();
 	}
 
 	@Nullable
-	public TeleportRecord getLastTeleport() {
+	public TeleportLog getLastTeleport() {
 		return this.lastTeleportRecord;
 	}
 

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
@@ -5,7 +5,9 @@ import com.feed_the_beast.ftblib.lib.math.TeleporterDimPos;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.INBTSerializable;
 
-public class TeleportLog implements INBTSerializable<NBTTagCompound>
+import java.util.Comparator;
+
+public class TeleportLog implements INBTSerializable<NBTTagCompound>,Comparable<TeleportLog>
 {
 	private static final String NBT_KEY_X = "x";
 	private static final String NBT_KEY_Y = "y";
@@ -13,6 +15,8 @@ public class TeleportLog implements INBTSerializable<NBTTagCompound>
 	private static final String NBT_KEY_DIMENSION = "dimension";
 	private static final String NBT_KEY_TELEPORT_TYPE = "teleportType";
 	private static final String NBT_KEY_CREATED_AT = "createdAt";
+
+	private static Comparator<TeleportLog> comparator = Comparator.comparing((log) -> log == null ? null:log.getCreatedAt(), Comparator.nullsFirst(Long::compareTo));
 
 	public TeleportType teleportType;
 
@@ -65,5 +69,11 @@ public class TeleportLog implements INBTSerializable<NBTTagCompound>
 
 	public long getCreatedAt() {
 		return this.createdAt;
+	}
+
+	@Override
+	public int compareTo(TeleportLog o)
+	{
+		return comparator.compare(this, o);
 	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
@@ -12,14 +12,21 @@ public class TeleportLog implements INBTSerializable<NBTTagCompound>
 	private static final String NBT_KEY_Z = "z";
 	private static final String NBT_KEY_DIMENSION = "dimension";
 	private static final String NBT_KEY_TELEPORT_TYPE = "teleportType";
+	private static final String NBT_KEY_CREATED_AT = "createdAt";
 
 	public TeleportType teleportType;
 
 	private BlockDimPos from;
+	private long createdAt;
 
-	TeleportLog(TeleportType teleportType, BlockDimPos from) {
+	public TeleportLog(NBTTagCompound nbt) {
+		deserializeNBT(nbt);
+	}
+
+	public TeleportLog(TeleportType teleportType, BlockDimPos from, long createdAt) {
 		this.teleportType = teleportType;
 		this.from = from;
+		this.createdAt = createdAt;
 	}
 
 	@Override
@@ -31,6 +38,7 @@ public class TeleportLog implements INBTSerializable<NBTTagCompound>
 		nbt.setInteger(NBT_KEY_Y, from.posY);
 		nbt.setInteger(NBT_KEY_Z, from.posZ);
 		nbt.setInteger(NBT_KEY_TELEPORT_TYPE, teleportType.ordinal());
+		nbt.setLong(NBT_KEY_CREATED_AT, createdAt);
 		return nbt;
 	}
 
@@ -53,5 +61,9 @@ public class TeleportLog implements INBTSerializable<NBTTagCompound>
 
 	public TeleporterDimPos teleporter() {
 		return getBlockDimPos().teleporter();
+	}
+
+	public long getCreatedAt() {
+		return this.createdAt;
 	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
@@ -13,8 +13,8 @@ public class TeleportLog implements INBTSerializable<NBTTagCompound>,Comparable<
 	private static final String NBT_KEY_Y = "y";
 	private static final String NBT_KEY_Z = "z";
 	private static final String NBT_KEY_DIMENSION = "dimension";
-	private static final String NBT_KEY_TELEPORT_TYPE = "teleportType";
-	private static final String NBT_KEY_CREATED_AT = "createdAt";
+	private static final String NBT_KEY_TELEPORT_TYPE = "teleport_type";
+	private static final String NBT_KEY_CREATED_AT = "created_at";
 
 	private static Comparator<TeleportLog> comparator = Comparator.comparing((log) -> log == null ? null:log.getCreatedAt(), Comparator.nullsFirst(Long::compareTo));
 

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportLog.java
@@ -5,7 +5,7 @@ import com.feed_the_beast.ftblib.lib.math.TeleporterDimPos;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.INBTSerializable;
 
-public class TeleportRecord implements INBTSerializable<NBTTagCompound>
+public class TeleportLog implements INBTSerializable<NBTTagCompound>
 {
 	private static final String NBT_KEY_X = "x";
 	private static final String NBT_KEY_Y = "y";
@@ -17,7 +17,7 @@ public class TeleportRecord implements INBTSerializable<NBTTagCompound>
 
 	private BlockDimPos from;
 
-	TeleportRecord(TeleportType teleportType, BlockDimPos from) {
+	TeleportLog(TeleportType teleportType, BlockDimPos from) {
 		this.teleportType = teleportType;
 		this.from = from;
 	}

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportRecord.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportRecord.java
@@ -1,0 +1,52 @@
+package com.feed_the_beast.ftbutilities.data;
+
+import com.feed_the_beast.ftblib.lib.math.BlockDimPos;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.INBTSerializable;
+
+public class TeleportRecord implements INBTSerializable<NBTTagCompound>
+{
+	private static final String NBT_KEY_X = "x";
+	private static final String NBT_KEY_Y = "y";
+	private static final String NBT_KEY_Z = "z";
+	private static final String NBT_KEY_DIMENSION = "dimension";
+	private static final String NBT_KEY_TELEPORT_TYPE = "teleportType";
+
+	public TeleportType teleportType;
+
+	private BlockDimPos from;
+
+	TeleportRecord(TeleportType teleportType, BlockDimPos from) {
+		this.teleportType = teleportType;
+		this.from = from;
+	}
+
+	@Override
+	public NBTTagCompound serializeNBT()
+	{
+		NBTTagCompound nbt = new NBTTagCompound();
+		nbt.setInteger(NBT_KEY_DIMENSION, from.dim);
+		nbt.setInteger(NBT_KEY_X, from.posX);
+		nbt.setInteger(NBT_KEY_Y, from.posY);
+		nbt.setInteger(NBT_KEY_Z, from.posZ);
+		nbt.setInteger(NBT_KEY_TELEPORT_TYPE, teleportType.ordinal());
+		return nbt;
+	}
+
+	@Override
+	public void deserializeNBT(NBTTagCompound nbt)
+	{
+		final int posX, posY, posZ, dimension, teleportType;
+		posX = nbt.getInteger(NBT_KEY_X);
+		posY = nbt.getInteger(NBT_KEY_Y);
+		posZ = nbt.getInteger(NBT_KEY_Z);
+		dimension = nbt.getInteger(NBT_KEY_DIMENSION);
+		teleportType = nbt.getInteger(NBT_KEY_TELEPORT_TYPE);
+		this.from = new BlockDimPos(posX, posY,posZ, dimension);
+		this.teleportType = TeleportType.values()[teleportType];
+	}
+
+	public BlockDimPos getBlockDimPos() {
+		return this.from;
+	}
+}

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportRecord.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportRecord.java
@@ -1,6 +1,7 @@
 package com.feed_the_beast.ftbutilities.data;
 
 import com.feed_the_beast.ftblib.lib.math.BlockDimPos;
+import com.feed_the_beast.ftblib.lib.math.TeleporterDimPos;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.INBTSerializable;
 
@@ -48,5 +49,9 @@ public class TeleportRecord implements INBTSerializable<NBTTagCompound>
 
 	public BlockDimPos getBlockDimPos() {
 		return this.from;
+	}
+
+	public TeleporterDimPos teleporter() {
+		return getBlockDimPos().teleporter();
 	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
@@ -39,7 +39,7 @@ public class TeleportTracker implements INBTSerializable<NBTTagCompound>
 	// Returns latest available according to permissions.
 	public TeleportLog getLastAvailableLog(GameProfile gameProfile) {
 		for(TeleportLog l : getSortedLogs()) {
-			if (permissionHandler.hasPermission(gameProfile, l.teleportType.getPermissionNode().toString(), null)) {
+			if (permissionHandler.hasPermission(gameProfile, l.teleportType.getPermission(), null)) {
 				return l;
 			}
 		}
@@ -68,8 +68,22 @@ public class TeleportTracker implements INBTSerializable<NBTTagCompound>
 	@Override
 	public void deserializeNBT(NBTTagCompound nbt)
 	{
+		if (nbt == null) {
+			return;
+		}
 		for(int i = 0; i < logs.length; i++) {
 			logs[i] = new TeleportLog(nbt.getCompoundTag(String.valueOf(i)));
 		}
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("{");
+		for(TeleportLog l : logs) {
+			builder.append(l.teleportType.toString() + ":" + l.getBlockDimPos());
+		}
+		builder.append("}");
+		return builder.toString();
 	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
@@ -8,6 +8,7 @@ import net.minecraftforge.server.permission.IPermissionHandler;
 import net.minecraftforge.server.permission.PermissionAPI;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public class TeleportTracker implements INBTSerializable<NBTTagCompound>
 {
@@ -30,8 +31,8 @@ public class TeleportTracker implements INBTSerializable<NBTTagCompound>
 	}
 
 	private TeleportLog[] getSortedLogs() {
-		TeleportLog[] toSort = logs.clone();
-		Arrays.sort(toSort, (a,b) -> (int)(b.getCreatedAt() - a.getCreatedAt()));
+		TeleportLog[] toSort = Arrays.stream(logs).filter((l) -> l != null).toArray(TeleportLog[]::new);
+		Arrays.sort(toSort, Collections.reverseOrder());
 		return toSort;
 	}
 

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
@@ -80,8 +80,12 @@ public class TeleportTracker implements INBTSerializable<NBTTagCompound>
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 		builder.append("{");
-		for(TeleportLog l : logs) {
+		for(int i = 0; i < logs.length; i++) {
+			final TeleportLog l = logs[i];
 			builder.append(l.teleportType.toString() + ":" + l.getBlockDimPos());
+			if (i != logs.length - 1) {
+				builder.append(",");
+			}
 		}
 		builder.append("}");
 		return builder.toString();

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportTracker.java
@@ -1,0 +1,74 @@
+package com.feed_the_beast.ftbutilities.data;
+
+import com.feed_the_beast.ftblib.lib.math.BlockDimPos;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.server.permission.IPermissionHandler;
+import net.minecraftforge.server.permission.PermissionAPI;
+
+import java.util.Arrays;
+
+public class TeleportTracker implements INBTSerializable<NBTTagCompound>
+{
+	private TeleportLog[] logs;
+	private IPermissionHandler permissionHandler;
+	public TeleportTracker() {
+		this(PermissionAPI.getPermissionHandler());
+	}
+
+	public TeleportTracker(IPermissionHandler permissionHandler) {
+		this.logs = new TeleportLog[TeleportType.values().length];
+		this.permissionHandler = permissionHandler;
+	}
+	public void logTeleport(TeleportType teleportType, BlockDimPos from, long worldTime) {
+		logs[teleportType.ordinal()] = new TeleportLog(teleportType, from, worldTime);
+	}
+
+	public TeleportLog getLastDeath() {
+		return logs[TeleportType.RESPAWN.ordinal()];
+	}
+
+	private TeleportLog[] getSortedLogs() {
+		TeleportLog[] toSort = logs.clone();
+		Arrays.sort(toSort, (a,b) -> (int)(b.getCreatedAt() - a.getCreatedAt()));
+		return toSort;
+	}
+
+	// Returns latest available according to permissions.
+	public TeleportLog getLastAvailableLog(GameProfile gameProfile) {
+		for(TeleportLog l : getSortedLogs()) {
+			if (permissionHandler.hasPermission(gameProfile, l.teleportType.getPermissionNode().toString(), null)) {
+				return l;
+			}
+		}
+		return null;
+	}
+
+	public TeleportLog getLastLog() {
+		TeleportLog[] logs = getSortedLogs();
+		return logs[0];
+	}
+
+	public void clearLog(TeleportType teleportType) {
+		logs[teleportType.ordinal()] = null;
+	}
+
+	@Override
+	public NBTTagCompound serializeNBT()
+	{
+		NBTTagCompound nbt = new NBTTagCompound();
+		for(int i = 0 ; i < logs.length; i++) {
+			nbt.setTag(String.valueOf(i), logs[i].serializeNBT());
+		}
+		return nbt;
+	}
+
+	@Override
+	public void deserializeNBT(NBTTagCompound nbt)
+	{
+		for(int i = 0; i < logs.length; i++) {
+			logs[i] = new TeleportLog(nbt.getCompoundTag(String.valueOf(i)));
+		}
+	}
+}

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
@@ -1,25 +1,24 @@
 package com.feed_the_beast.ftbutilities.data;
 
-import com.feed_the_beast.ftblib.lib.util.misc.Node;
 import com.feed_the_beast.ftbutilities.FTBUtilitiesPermissions;
 
 public enum TeleportType
 {
 	HOME(FTBUtilitiesPermissions.HOMES_BACK),
 	WARP(FTBUtilitiesPermissions.WARPS_BACK),
-	BACK(null),
+	BACK(FTBUtilitiesPermissions.BACK_BACK),
 	SPAWN(FTBUtilitiesPermissions.SPAWN_BACK),
 	TPA(FTBUtilitiesPermissions.TPA_BACK),
 	RTP(FTBUtilitiesPermissions.RTP_BACK),
 	RESPAWN(FTBUtilitiesPermissions.RESPAWN_BACK);
 
-	private Node permission;
+	private String permission;
 
-	TeleportType(Node node) {
+	TeleportType(String node) {
 		this.permission = node;
 	}
 
-	public Node getPermissionNode() {
+	public String getPermission() {
 		return this.permission;
 	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
@@ -1,0 +1,11 @@
+package com.feed_the_beast.ftbutilities.data;
+
+public enum TeleportType
+{
+	HOME,
+	WARP,
+	BACK,
+	SPAWN,
+	TPA,
+	RTP,
+}

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
@@ -8,4 +8,5 @@ public enum TeleportType
 	SPAWN,
 	TPA,
 	RTP,
+	RESPAWN,
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
@@ -1,12 +1,25 @@
 package com.feed_the_beast.ftbutilities.data;
 
+import com.feed_the_beast.ftblib.lib.util.misc.Node;
+import com.feed_the_beast.ftbutilities.FTBUtilitiesPermissions;
+
 public enum TeleportType
 {
-	HOME,
-	WARP,
-	BACK,
-	SPAWN,
-	TPA,
-	RTP,
-	RESPAWN,
+	HOME(FTBUtilitiesPermissions.HOMES_BACK),
+	WARP(FTBUtilitiesPermissions.WARPS_BACK),
+	BACK(null),
+	SPAWN(FTBUtilitiesPermissions.SPAWN_BACK),
+	TPA(FTBUtilitiesPermissions.TPA_BACK),
+	RTP(FTBUtilitiesPermissions.RTP_BACK),
+	RESPAWN(FTBUtilitiesPermissions.RESPAWN_BACK);
+
+	private Node permission;
+
+	TeleportType(Node node) {
+		this.permission = node;
+	}
+
+	public Node getPermissionNode() {
+		return this.permission;
+	}
 }

--- a/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/TeleportType.java
@@ -1,24 +1,39 @@
 package com.feed_the_beast.ftbutilities.data;
 
+import com.feed_the_beast.ftblib.lib.util.misc.Node;
 import com.feed_the_beast.ftbutilities.FTBUtilitiesPermissions;
+
+import javax.annotation.Nullable;
 
 public enum TeleportType
 {
-	HOME(FTBUtilitiesPermissions.HOMES_BACK),
-	WARP(FTBUtilitiesPermissions.WARPS_BACK),
-	BACK(FTBUtilitiesPermissions.BACK_BACK),
-	SPAWN(FTBUtilitiesPermissions.SPAWN_BACK),
-	TPA(FTBUtilitiesPermissions.TPA_BACK),
-	RTP(FTBUtilitiesPermissions.RTP_BACK),
-	RESPAWN(FTBUtilitiesPermissions.RESPAWN_BACK);
+	HOME(FTBUtilitiesPermissions.HOMES_BACK, FTBUtilitiesPermissions.HOMES_WARMUP, FTBUtilitiesPermissions.HOMES_COOLDOWN),
+	WARP(FTBUtilitiesPermissions.WARPS_BACK, FTBUtilitiesPermissions.WARPS_WARMUP, FTBUtilitiesPermissions.WARPS_COOLDOWN),
+	BACK(FTBUtilitiesPermissions.BACK_BACK, FTBUtilitiesPermissions.BACK_WARMUP, FTBUtilitiesPermissions.BACK_COOLDOWN),
+	SPAWN(FTBUtilitiesPermissions.SPAWN_BACK, FTBUtilitiesPermissions.SPAWN_WARMUP, FTBUtilitiesPermissions.SPAWN_COOLDOWN),
+	TPA(FTBUtilitiesPermissions.TPA_BACK, FTBUtilitiesPermissions.TPA_WARMUP, FTBUtilitiesPermissions.TPA_COOLDOWN),
+	RTP(FTBUtilitiesPermissions.RTP_BACK, FTBUtilitiesPermissions.RTP_WARMUP, FTBUtilitiesPermissions.RTP_COOLDOWN),
+	RESPAWN(FTBUtilitiesPermissions.RESPAWN_BACK, null,null);
 
 	private String permission;
+	private Node warmup;
+	private Node cooldown;
 
-	TeleportType(String node) {
+	TeleportType(String node, @Nullable Node warmup,@Nullable Node cooldown) {
 		this.permission = node;
+		this.warmup = warmup;
+		this.cooldown = cooldown;
 	}
 
 	public String getPermission() {
 		return this.permission;
+	}
+
+	public Node getWarmupPermission() {
+		return this.warmup;
+	}
+
+	public Node getCooldownPermission() {
+		return this.cooldown;
 	}
 }


### PR DESCRIPTION
Related to #963 

- [x] Record teleport position
- [x] Add permission node for back permission of each teleport type

Add new permissions:
1. `ftbutilities.back.home`
1. `ftbutilities.back.warp`
1. `ftbutilities.back.spawn`
1. `ftbutilities.back.tpa`
1. `ftbutilities.back.rtp`
1. `ftbutilities.back.respawn`
1. `ftbutilities.back.back`